### PR TITLE
Added Python version of the app

### DIFF
--- a/source/src/main/python/log_analysis_python.py
+++ b/source/src/main/python/log_analysis_python.py
@@ -1,5 +1,13 @@
 %spark.pyspark
 
+"""
+Log analysis application that processes data in Apache server log format.
+Example datasets can be found in:
+http://ita.ee.lbl.gov/html/contrib/ClarkNet-HTTP.html
+This code is intended to be executed interactively in a Zeppelin session.
+Please specify input file (i.e. log_file variable) before running.
+"""
+
 import datetime
 import os
 import re
@@ -11,7 +19,9 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-log_file = '/Users/stephen/Desktop/misc/clarknet_access_log_Sep4'
+
+# Specify input file here
+log_file = 'path_to_input_file'
 
 APACHE_LOG_REGEX = '^(\S+) (\S+) (\S+) \[([\w:/]+\s[+\-]\d{4})\] "(\S+) (\S+)\s*(\S*)" (\d{3}) (\S+)'
 months = {'Jan': 1, 'Feb': 2, 'Mar':3, 'Apr':4, 'May':5, 'Jun':6, 'Jul':7, 'Aug':8,  'Sep': 9, 'Oct':10, 'Nov': 11, 'Dec': 12}
@@ -59,10 +69,13 @@ def parse_apache_logs():
 
 parsed_logs, access_logs, failed_logs = parse_apache_logs()
 
+# Output statistics on request payload sizes
 payload_sizes = access_logs.map(lambda log: log.payload_size).cache()
 payload_size_avg = payload_sizes.reduce(lambda a, b : a + b) / payload_sizes.count()
 print 'Payload Size Avg: %i, Min: %i, Max: %s' % (payload_size_avg, payload_sizes.min(), payload_sizes.max())
 
+
+# Generate variables for use in plotting
 status_counts = access_logs.map(lambda log: (log.status, 1)).reduceByKey(lambda a, b: a + b).cache()
 labels = status_counts.map(lambda (x, y): x).collect()
 count = access_logs.count()
@@ -84,6 +97,7 @@ for text, autotext in zip(texts, autotexts):
         text.set_text('')
 plt.legend(labels, loc=(0.80, -0.1), shadow=True)
 
+# Output any 10 hosts that appeared more than 20 times
 ip_counts = access_logs.map(lambda log: (log.ip, 1))
 host_more_than_20 = ip_counts.reduceByKey(lambda a, b : a + b).filter(lambda s: s[1] > 20)
 hosts_pick_10 = host_more_than_20.map(lambda s: s[0]).take(10)

--- a/source/src/main/python/log_analysis_python.py
+++ b/source/src/main/python/log_analysis_python.py
@@ -1,0 +1,90 @@
+%spark.pyspark
+
+import datetime
+import os
+import re
+import sys
+
+from pyspark.sql import Row
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+log_file = '/Users/stephen/Desktop/misc/clarknet_access_log_Sep4'
+
+APACHE_LOG_REGEX = '^(\S+) (\S+) (\S+) \[([\w:/]+\s[+\-]\d{4})\] "(\S+) (\S+)\s*(\S*)" (\d{3}) (\S+)'
+months = {'Jan': 1, 'Feb': 2, 'Mar':3, 'Apr':4, 'May':5, 'Jun':6, 'Jul':7, 'Aug':8,  'Sep': 9, 'Oct':10, 'Nov': 11, 'Dec': 12}
+
+
+def parse_apache_log_time(s):
+    return datetime.datetime(int(s[7:11]), months[s[3:6]], int(s[0:2]), int(s[12:14]), int(s[15:17]), int(s[18:20]))
+
+
+def parse_apache_log(line):
+    match = re.search(APACHE_LOG_REGEX, line)
+    if match is None:
+        return (line, 0)
+    payload_size_field = match.group(9)
+    if payload_size_field == '-':
+        payload_size = long(0)
+    else:
+        payload_size = long(match.group(9))
+    return (Row(
+        ip            = match.group(1),
+        client_ic     = match.group(2),
+        user          = match.group(3),
+        date_time     = parse_apache_log_time(match.group(4)),
+        method        = match.group(5),
+        endpoint      = match.group(6),
+        protocol      = match.group(7),
+        status        = int(match.group(8)),
+        payload_size  = payload_size
+    ), 1)
+
+
+def parse_apache_logs():
+    parsed_logs = sc.textFile(log_file).map(parse_apache_log).cache()
+
+    access_logs = parsed_logs.filter(lambda s: s[1] == 1).map(lambda s: s[0]).cache()
+    failed_logs = parsed_logs.filter(lambda s: s[1] == 0).map(lambda s: s[0])
+
+    failed_logs_count = failed_logs.count()
+    if failed_logs_count > 0:
+        print 'Number of invalid logs: %d' % failed_logs_count
+
+    print 'Parsed %d lines. Successfully parsed %d lines. Failed to parse %d lines' % (parsed_logs.count(), access_logs.count(), failed_logs_count)
+    return parsed_logs, access_logs, failed_logs
+
+
+parsed_logs, access_logs, failed_logs = parse_apache_logs()
+
+payload_sizes = access_logs.map(lambda log: log.payload_size).cache()
+payload_size_avg = payload_sizes.reduce(lambda a, b : a + b) / payload_sizes.count()
+print 'Payload Size Avg: %i, Min: %i, Max: %s' % (payload_size_avg, payload_sizes.min(), payload_sizes.max())
+
+status_counts = access_logs.map(lambda log: (log.status, 1)).reduceByKey(lambda a, b: a + b).cache()
+labels = status_counts.map(lambda (x, y): x).collect()
+count = access_logs.count()
+fractions = status_counts.map(lambda (x, y): (float(y) / count)).collect()
+
+
+# Plot a pie chart of status code counts
+def pie_chart_format(value):
+    return '' if value < 7 else '%.0f%%' % value
+
+fig = plt.figure(figsize=(4.5, 4.5), facecolor='white', edgecolor='white')
+colors = ['yellow', 'green', 'gold', 'purple', 'blue', 'yellow', 'black']
+explode = (0.05, 0.05, 0.1, 0, 0, 0, 0)
+patches, texts, autotexts = plt.pie(fractions, labels=labels, colors=colors,
+                                    explode=explode, autopct=pie_chart_format,
+                                    shadow=False,  startangle=125)
+for text, autotext in zip(texts, autotexts):
+    if autotext.get_text() == '':
+        text.set_text('')
+plt.legend(labels, loc=(0.80, -0.1), shadow=True)
+
+ip_counts = access_logs.map(lambda log: (log.ip, 1))
+host_more_than_20 = ip_counts.reduceByKey(lambda a, b : a + b).filter(lambda s: s[1] > 20)
+hosts_pick_10 = host_more_than_20.map(lambda s: s[0]).take(10)
+print 'Some 10 hosts that have accessed more then 20 times: %s' % hosts_pick_10

--- a/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
+++ b/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
@@ -1,9 +1,8 @@
 package com.lightbend.fdp.sample
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SQLContext
 import org.joda.time.DateTime
 
 /*
@@ -19,15 +18,16 @@ object LogAnalysis {
       | HTTP/1.1" 304 306""".stripMargin.lines.mkString
   )
 
+  case class LogFields(ip: String, clientId: String, user: String, dataTime: String, method: String,
+                       endpoint: String, protocol: String, status: String, payloadSize: Long)
+
   def main(args: Array[String]) {
 
     val appName = "Apache Log Analysis"
     val sparkConf = new SparkConf().setAppName(appName)
     val sc = new SparkContext(sparkConf)
-    val spark = SparkSession.builder()
-      .master("local")
-      .appName(appName)
-      .getOrCreate()
+    val sqlContext = new org.apache.spark.sql.SQLContext(sc)
+    import sqlContext.implicits._
 
     val dataSet = if (args.length == 1) sc.textFile(args(0)) else sc.parallelize(exampleApacheLogs)
 
@@ -35,17 +35,6 @@ object LogAnalysis {
 
     val month_map = Map("Jan" -> 1, "Feb" -> 2, "Mar" -> 3, "Apr" -> 4, "May" -> 5, "Jun" -> 6, "Jul" ->7,
       "Aug" -> 8,  "Sep" -> 9, "Oct" -> 10, "Nov" -> 11, "Dec" -> 12)
-
-    val schema = new StructType(Array(
-      StructField("ip", StringType, false),
-      StructField("clientId", StringType, false),
-      StructField("user", StringType, false),
-      StructField("dateTime", StringType, false),
-      StructField("method", StringType, false),
-      StructField("endpoint", StringType, false),
-      StructField("protocol", StringType, false),
-      StructField("status", StringType, false),
-      StructField("payloadSize", LongType, false)))
 
     /** Tracks the total query count and number of aggregate bytes for a particular group. */
     case class Stats(count: Int, numBytes: Int) extends Serializable {
@@ -71,13 +60,13 @@ object LogAnalysis {
     }
 
     // Convert Apache time format into a Joda datetime object
-    def parseApacheTime(s: String): DateTime = {
-      new DateTime(s.substring(7, 11).toInt,
+    def parseApacheTime(s: String): String = {
+      (new DateTime(s.substring(7, 11).toInt,
         month_map(s.substring(3, 6)),
         s.substring(0, 2).toInt,
         s.substring(12, 14).toInt,
         s.substring(15, 17).toInt,
-        s.substring(18, 20).toInt)
+        s.substring(18, 20).toInt)).toString()
     }
 
     /* Parse a line in the Apache Common Log format
@@ -88,40 +77,35 @@ object LogAnalysis {
       logRegex.findFirstIn(line) match {
         case Some(logRegex(ip, clientId, user, dateTime, method, endpoint, protocol, status, bytes)) =>
           val size = if (bytes == "-") 0L else bytes.toLong
-          ((ip, clientId, user, dateTime, method, endpoint, protocol, status, size), 1)
+          (LogFields(ip, clientId, user, dateTime, method, endpoint, protocol, status, size), 1)
         case _ => (line, 0)
       }
     }
 
     def parseLogs() = {
-      val parsedLogs = dataSet.map(parseApacheLogLine).cache()
-      val accessLogs =
-        parsedLogs.filter(s => s._2 == 1).map(s => s._1).cache().asInstanceOf[RDD[(String, String, String, DateTime, String, String, String, String, Long)]]
+      val parsedLogs = dataSet.map(parseApacheLogLine)
+      val accessLogs = parsedLogs.filter(s => s._2 == 1).map(s => s._1).map(_.asInstanceOf[LogFields])
       val failedLogs = parsedLogs.filter(s => s._2 == 0).map(s => s._1)
       (parsedLogs, accessLogs, failedLogs)
     }
 
     val (_, accessLogs, _) = parseLogs()
-    val rowAccessLogs = accessLogs.map(elem => Row(elem._1, elem._2, elem._3, elem._4, elem._5, elem._6, elem._7, elem._8, elem._9))
-    val logDf = spark.createDataFrame(rowAccessLogs, schema)
+    accessLogs.toDF().registerTempTable("logs")
 
-    println("Payload size stats:")
-    logDf.describe("payloadSize").show()
-
-    val statusCodeToCount = accessLogs.map(log => (log._8, 1)).reduceByKey((a, b) => a + b).cache()
+    val statusCodeToCount = accessLogs.map(log => (log.status, 1)).reduceByKey((a, b) => a + b).cache()
     val statusCodeToCountList = statusCodeToCount.take(100)
 
     println("Response codes and their counts:")
     statusCodeToCountList.foreach(println)
 
-    val ipCounts = accessLogs.map(log => (log._1, 1)).reduceByKey((a, b) => a + b)
+    val ipCounts = accessLogs.map(log => (log.ip, 1)).reduceByKey((a, b) => a + b)
     val ipMoreThan10 = ipCounts.filter(x => x._2 > 10)
     val ipPick20 = ipMoreThan10.map(x => x._1).take(20)
     println("Any 20 hosts that have accessed more then 10 times:")
     ipPick20.foreach(println)
 
 
-    val endpointCounts = accessLogs.map(log => (log._6, 1)).reduceByKey((a, b) => a + b)
+    val endpointCounts = accessLogs.map(log => (log.endpoint, 1)).reduceByKey((a, b) => a + b)
     val top10points = endpointCounts.takeOrdered(10)(Ordering[Int].on(x => -1 * x._2))
     println("Top 10 endpoints:")
     top10points.foreach(println)

--- a/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
+++ b/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
@@ -56,9 +56,9 @@ object LogAnalysis {
     def extractKey(line: String): Option[(String,String,String)] = {
       logRegex.findFirstIn(line) match {
         case Some(logRegex(ip, _, user, _, method, endpoint, protocol, _, _)) =>
-          if (user != "\"-\"") (ip, user, method ++ endpoint ++ protocol)
-          else (null, null, null)
-        case _ => (null, null, null)
+          if (user != "\"-\"") Some(ip, user, method ++ endpoint ++ protocol)
+          else Option(null, null, null)
+        case _ => Option(null, null, null)
       }
     }
 

--- a/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
+++ b/source/src/main/scala/com/lightbend/fdp/sample/LogAnalysis.scala
@@ -36,7 +36,7 @@ object LogAnalysis {
     val month_map = Map("Jan" -> 1, "Feb" -> 2, "Mar" -> 3, "Apr" -> 4, "May" -> 5, "Jun" -> 6, "Jul" ->7,
       "Aug" -> 8,  "Sep" -> 9, "Oct" -> 10, "Nov" -> 11, "Dec" -> 12)
 
-    val schema: StructType = new StructType(Array(
+    val schema = new StructType(Array(
       StructField("ip", StringType, false),
       StructField("clientId", StringType, false),
       StructField("user", StringType, false),
@@ -48,7 +48,7 @@ object LogAnalysis {
       StructField("payloadSize", LongType, false)))
 
     /** Tracks the total query count and number of aggregate bytes for a particular group. */
-    case class Stats(val count: Int, val numBytes: Int) extends Serializable {
+    case class Stats(count: Int, numBytes: Int) extends Serializable {
       def +(other: Stats): Stats = new Stats(count + other.count, numBytes + other.numBytes)
       override def toString: String = "bytes=%s\tn=%s".format(numBytes, count)
     }


### PR DESCRIPTION
Zeppelin version 0.5.6 provided in DC/OS universe does not support Spark dataframes, making plotting with Spark SQL difficult. This Python version of the app uses Matplotlib and is tested with Zeppelin 0.5.6.  Eventually we'll have our own fork of DC/OS universe and install latest Zeppelin 0.7.0.